### PR TITLE
Add weather slice with validation

### DIFF
--- a/src/Features/Weather/CreateWeather.cs
+++ b/src/Features/Weather/CreateWeather.cs
@@ -1,0 +1,25 @@
+using MediatR;
+
+namespace Features.Weather
+{
+    public class CreateWeather
+    {
+        public record Command(string Date, int TemperatureC, string Summary) : IRequest<WeatherForecast>;
+
+        public class Handler : IRequestHandler<Command, WeatherForecast>
+        {
+            public Task<WeatherForecast> Handle(Command request, CancellationToken cancellationToken)
+            {
+                var parsedDate = DateTime.Parse(request.Date);
+                var forecast = new WeatherForecast
+                {
+                    Date = parsedDate,
+                    TemperatureC = request.TemperatureC,
+                    Summary = request.Summary
+                };
+
+                return Task.FromResult(forecast);
+            }
+        }
+    }
+}

--- a/src/Features/Weather/CreateWeatherValidator.cs
+++ b/src/Features/Weather/CreateWeatherValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace Features.Weather
+{
+    public class CreateWeatherValidator : AbstractValidator<CreateWeather.Command>
+    {
+        public CreateWeatherValidator()
+        {
+            RuleFor(x => x.TemperatureC)
+                .InclusiveBetween(-50, 60);
+
+            RuleFor(x => x.Date)
+                .NotEmpty()
+                .Must(date => DateTime.TryParse(date, out _))
+                .WithMessage("Date must be in a valid format");
+
+            RuleFor(x => x.Summary)
+                .NotEmpty();
+        }
+    }
+}

--- a/src/Features/Weather/GetWeather.cs
+++ b/src/Features/Weather/GetWeather.cs
@@ -1,0 +1,24 @@
+using MediatR;
+
+namespace Features.Weather
+{
+    public class GetWeather
+    {
+        public record Query(DateTime Date) : IRequest<WeatherForecast>;
+
+        public class Handler : IRequestHandler<Query, WeatherForecast>
+        {
+            public Task<WeatherForecast> Handle(Query request, CancellationToken cancellationToken)
+            {
+                var forecast = new WeatherForecast
+                {
+                    Date = request.Date,
+                    TemperatureC = 25,
+                    Summary = "Sample"
+                };
+
+                return Task.FromResult(forecast);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new vertical slice files `GetWeather.cs` and `CreateWeather.cs`
- include MediatR handlers alongside the request types
- add `CreateWeatherValidator` with FluentValidation rules for temperature range and date format

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419bc574a0832c9413f617416f0d5a