### PR TITLE
Add minimal API endpoints with middleware

### DIFF
--- a/src/Api/ApiResponse.cs
+++ b/src/Api/ApiResponse.cs
@@ -1,0 +1,7 @@
+namespace Api;
+
+public record ApiResponse<T>(T Data, bool Success = true, string? Error = null)
+{
+    public static ApiResponse<T> Ok(T data) => new(data);
+    public static ApiResponse<T> Fail(string error) => new(default!, false, error);
+}

--- a/src/Api/GlobalExceptionMiddleware.cs
+++ b/src/Api/GlobalExceptionMiddleware.cs
@@ -1,0 +1,29 @@
+namespace Api;
+
+public class GlobalExceptionMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionMiddleware> _logger;
+
+    public GlobalExceptionMiddleware(RequestDelegate next, ILogger<GlobalExceptionMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            context.Response.ContentType = "application/json";
+            var response = ApiResponse<string>.Fail("An unexpected error occurred");
+            await context.Response.WriteAsJsonAsync(response);
+        }
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,12 +1,11 @@
-using System;
+using Api;
 
-namespace Api
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Console.WriteLine("API startup placeholder");
-        }
-    }
-}
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.UseMiddleware<GlobalExceptionMiddleware>();
+
+app.MapWeatherEndpoints();
+
+app.Run();

--- a/src/Api/WeatherEndpoints.cs
+++ b/src/Api/WeatherEndpoints.cs
@@ -1,0 +1,36 @@
+using Features.Weather;
+
+namespace Api;
+
+public static class WeatherEndpoints
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    public static void MapWeatherEndpoints(this WebApplication app)
+    {
+        app.MapGet("/weather", GetWeather);
+        app.MapPost("/weather", PostWeather);
+    }
+
+    private static IResult GetWeather()
+    {
+        var rng = new Random();
+        var forecast = Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateTime.Now.AddDays(index),
+            TemperatureC = rng.Next(-20, 55),
+            Summary = Summaries[rng.Next(Summaries.Length)]
+        });
+
+        return Results.Json(ApiResponse.Ok(forecast));
+    }
+
+    private static IResult PostWeather(WeatherForecast forecast)
+    {
+        // Echo back the forecast or store it somewhere in a real app
+        return Results.Json(ApiResponse.Ok(forecast));
+    }
+}


### PR DESCRIPTION
## Summary
- convert `Program.cs` to ASP.NET minimal API style
- implement `WeatherEndpoints` with GET and POST routes
- add `ApiResponse<T>` wrapper for consistent responses
- add global exception handling middleware

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419bd2b8b0832ca118ad32b1eca9d7